### PR TITLE
define AT_FDCWD

### DIFF
--- a/override.c
+++ b/override.c
@@ -145,7 +145,7 @@ static void initialize() {
     }
 
     char buffer[MAXPATH];
-    int buffer_level;
+    int buffer_level = 0;
     int its_key_now = 1;
     for(;;) {
         if (n_overrides >= MAXOVERRIDES) {

--- a/override.c
+++ b/override.c
@@ -15,6 +15,7 @@
 //#include <fcntl.h>
 #define _FCNTL_H
 #include <bits/fcntl.h>
+#define AT_FDCWD -100
 
 
 static int absolutize_path(char *outpath, int outpath_s, const char* pathname, int dirfd) {


### PR DESCRIPTION
fix compile error:

```
override.c:24:22: error: 'AT_FDCWD' undeclared (first use in this function)
```

fix warning:

```
override.c:199:17: warning: 'buffer_level' may be used uninitialized
```
